### PR TITLE
Fix: Update image paths to Artifact Registry

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,10 @@
 steps:
   # Build the container image
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/hopper:$COMMIT_SHA', '.']
+    args: ['build', '-t', 'us-central1-docker.pkg.dev/$PROJECT_ID/hopper/hopper:$COMMIT_SHA', '.']
   # Push the container image to Container Registry
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'gcr.io/$PROJECT_ID/hopper:$COMMIT_SHA']
+    args: ['push', 'us-central1-docker.pkg.dev/$PROJECT_ID/hopper/hopper:$COMMIT_SHA']
   # Deploy container image to Cloud Run
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: gcloud
@@ -13,7 +13,7 @@ steps:
       - 'deploy'
       - 'hopper'
       - '--image'
-      - 'gcr.io/$PROJECT_ID/hopper:$COMMIT_SHA'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/hopper/hopper:$COMMIT_SHA'
       - '--region'
       - 'us-central1' # You can change this to your preferred region
       - '--platform'
@@ -47,7 +47,7 @@ steps:
       - '--generation'
       - '1'
 images:
-  - 'gcr.io/$PROJECT_ID/hopper:$COMMIT_SHA'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/hopper/hopper:$COMMIT_SHA'
 logsBucket: 'gs://cloudbuild-log-$PROJECT_ID'
 options:
   logging: GCS_ONLY


### PR DESCRIPTION
Cloud Build configuration (`cloudbuild.yaml`) has been updated to use Artifact Registry for Docker images.

- Changed image paths from `gcr.io/$PROJECT_ID/hopper` to `us-central1-docker.pkg.dev/$PROJECT_ID/hopper/hopper`.
- This addresses the deprecation of Container Registry.